### PR TITLE
Escape user data in email template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,11 @@
     "psr-4": {
       "DeliciousBrains\\WPPromoter\\": "src/"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "boxuk/wp-muplugin-loader": true,
+      "composer/installers": true
+    }
   }
 }

--- a/src/Email.php
+++ b/src/Email.php
@@ -144,7 +144,7 @@ class Email {
 			$subject = get_post_meta( $post->ID, 'article_promo_email_subject', true );
 
 			if ( ! $message ) {
-				$message = "{% if subscriber.first_name %}Hey {{ subscriber.first_name }}{% else %}Hey{% endif %},\n\n\n\n[link]\n\nCheers,\n\n[signature]";
+				$message = "{% if subscriber.first_name %}Hey {{ subscriber.first_name | escape }}{% else %}Hey{% endif %},\n\n\n\n[link]\n\nCheers,\n\n[signature]";
 			}
 
 			wp_nonce_field( 'article-promo-email', 'article_promo_email_nonce' );


### PR DESCRIPTION
Resolves #10 

This PR fixes the escaping of user-provided data in the suggested email template.

This template is to be copied to Drip, which uses the Liquid templating system. And while the `escape` filter is not documented in [Drip's docs](https://help.drip.com/hc/en-us/articles/4424710548493-Filters), it is documented in the official [Liquid docs](https://shopify.github.io/liquid/filters/escape/).

## Testing

This will be hard to completely end-to-end test. But you can at least see it working in WordPress by:
1. Updating the `composer.json` of your local copy of a site using the package to use a local copy of the package:

```
"repositories": [
    {
      "type": "path",
      "url": "/your/local/path/wp-post-promoter"
    },
   ...
],
```

2. Run `composer update deliciousbrains/wp-post-promoter`
3. Log in to the local WordPress site and add a new post.
4. You should see an "Email Draft" meta-box showing the updated template with the `escape` filter added.